### PR TITLE
chore: remove quotes from the header value of x-api-secret

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -15,7 +15,7 @@ for (let key in outputs) {
 	await $`npm publish -w ${dir}/${pkg}`
 	let pkgjson = await readPackage({cwd: `${dir}/${pkg}`})
 	await $`curl -X POST \
-        -H 'Content-Type: application/json' -H 'X-Api-Key: ${REPO_DATA_KEY}' -H 'X-Api-Secret: "${REPO_DATA_SECRET}"' \
+        -H 'Content-Type: application/json' -H 'X-Api-Key: ${REPO_DATA_KEY}' -H 'X-Api-Secret: ${REPO_DATA_SECRET}' \
         -d '{"packageName": "${pkg}", "version": "v${pkgjson.version}", "type":"npm"}' \
         https://origami-repo-data-monorepo.herokuapp.com/v1/queue`
 }


### PR DESCRIPTION
I think these quotes were sent as part of the header value by accident and that this should make the request work 🤞 